### PR TITLE
A few additional changes to google stt

### DIFF
--- a/plugins/stt/google-stt/google.py
+++ b/plugins/stt/google-stt/google.py
@@ -1,7 +1,8 @@
 import logging
+from collections import OrderedDict
 from naomi import plugin
 from naomi import profile
-from os import environ
+import os
 
 from google.cloud import speech
 from google.cloud.speech import enums
@@ -30,6 +31,21 @@ class GoogleSTTPlugin(plugin.STTPlugin):
 
     """
 
+    settings = OrderedDict(
+        [
+            (
+                ("google", "authentication_json"), {
+                    "type": "file",
+                    "title": "Google application credentials (*.json)",
+                    "description": "This is a json file that allows your assistant to use the Google Speech API for converting speech to text. You need to generate and download an google cloud API key. Details here: https://cloud.google.com/speech-to-text/docs/quickstart-protocol",
+                    "validation": lambda filename: os.path.exists(os.path.expanduser(filename)),
+                    "invalidmsg": lambda filename: "File {} does not exist".format(filename),
+                    "default": os.getenv('GOOGLE_APPLICATION_CREDENTIALS')
+                }
+            )
+        ]
+    )
+
     def __init__(self, *args, **kwargs):
         plugin.STTPlugin.__init__(self, *args, **kwargs)
         # FIXME: get init args from config
@@ -38,7 +54,7 @@ class GoogleSTTPlugin(plugin.STTPlugin):
         self._language = profile.get_profile_var(['language'], 'en-US')
         self._config = None
 
-        if(google_env_var in environ):
+        if(google_env_var in os.environ):
             self._client = speech.SpeechClient()
         else:
             credentials_json = profile.get_profile_var(["google", "credentials_json"])

--- a/plugins/stt/google-stt/google.py
+++ b/plugins/stt/google-stt/google.py
@@ -1,12 +1,17 @@
 import logging
 from naomi import plugin
+from naomi import profile
+from os import environ
 
 from google.cloud import speech
 from google.cloud.speech import enums
 from google.cloud.speech import types
-from google.api_core.exceptions import GoogleAPICallError,RetryError
+from google.api_core.exceptions import GoogleAPICallError, RetryError
 
 from google.oauth2 import service_account
+
+
+google_env_var = "GOOGLE_APPLICATION_CREDENTIALS"
 
 
 class GoogleSTTPlugin(plugin.STTPlugin):
@@ -15,7 +20,7 @@ class GoogleSTTPlugin(plugin.STTPlugin):
     Uses the google python client:
     https://googleapis.github.io/google-cloud-python/latest/speech/index.html
 
-    You need to download an google cloud API key and set its location using the 
+    You need to download an google cloud API key and set its location using the
     environment variable GOOGLE_APPLICATION_CREDENTIALS. Details here:
 
     https://cloud.google.com/speech-to-text/docs/quickstart-protocol
@@ -30,24 +35,16 @@ class GoogleSTTPlugin(plugin.STTPlugin):
         # FIXME: get init args from config
 
         self._logger = logging.getLogger(__name__)
-        self._language = 'en-US'
+        self._language = profile.get_profile_var(['language'], 'en-US')
         self._config = None
-        try:
-            language = self.profile['language']
-        except KeyError:
-            language = 'en-US'
 
-        # retrieve the location of the crediantials json from the user settings
-        try:
-            credentials_json = self.profile['google']['credentials_json']
-        except KeyError:
-            credentials_json = None
-
-        # set up the google speech client
-        cred = service_account.Credentials.from_service_account_file(credentials_json)
-        self._client = speech.SpeechClient(credentials=cred)
+        if(google_env_var in environ):
+            self._client = speech.SpeechClient()
+        else:
+            credentials_json = profile.get_profile_var(["google", "credentials_json"])
+            cred = service_account.Credentials.from_service_account_file(credentials_json)
+            self._client = speech.SpeechClient(credentials=cred)
         self._regenerate_config()
-
 
     @property
     def language(self):
@@ -59,11 +56,7 @@ class GoogleSTTPlugin(plugin.STTPlugin):
         self._regenerate_config()
 
     def _regenerate_config(self):
-        keyword = None
-        try:
-            keyword = self.profile["keyword"]
-        except:
-            pass
+        keyword = profile.get_profile_var(["keyword"], "Naomi")
 
         self._config = types.RecognitionConfig(
                            encoding=enums.RecognitionConfig.AudioEncoding.LINEAR16,
@@ -71,7 +64,6 @@ class GoogleSTTPlugin(plugin.STTPlugin):
                            speech_contexts=[speech.types.SpeechContext(phrases=[keyword])] if keyword else None,
                            model="command_and_search"
                        )
-
 
     def transcribe(self, fp):
         """
@@ -90,7 +82,7 @@ class GoogleSTTPlugin(plugin.STTPlugin):
         audio = types.RecognitionAudio(content=content)
         try:
             response = self._client.recognize(self._config, audio)
-        except GoogleAPICallError as e: 
+        except GoogleAPICallError as e:
             # request failed for any reason
             self._logger.warning('Google STT retry error. response: %s', e.args[0])
             results = []
@@ -103,9 +95,8 @@ class GoogleSTTPlugin(plugin.STTPlugin):
             results = []
         else:
             # Convert all results to uppercase
-            results = [ str(result.alternatives[0].transcript).upper() for 
+            results = [str(result.alternatives[0].transcript).upper() for
                             result in response.results]
             self._logger.info('Transcribed: %r', results)
 
         return results
-

--- a/plugins/stt/google-stt/tests/test_googlesttplugin.py
+++ b/plugins/stt/google-stt/tests/test_googlesttplugin.py
@@ -2,8 +2,9 @@
 import unittest
 from naomi import paths
 from naomi import testutils
+from naomi import profile
 from .. import google
-from os import environ
+import os
 
 
 class TestGoogleSTTPlugin(unittest.TestCase):
@@ -12,9 +13,16 @@ class TestGoogleSTTPlugin(unittest.TestCase):
         self.naomi_clip = paths.data('audio', 'naomi.wav')
         self.time_clip = paths.data('audio', 'time.wav')
 
-        google_env_var = "GOOGLE_APPLICATION_CREDENTIALS"
-        if google_env_var not in environ:
+        # google_env_var = "GOOGLE_APPLICATION_CREDENTIALS"
+        google_env_var = google.google_env_var
+        if(google_env_var in os.environ):
+            credentials_json = os.getenv(google_env_var)
+        elif profile.check_profile_var_exists(["google", "credentials_json"]):
+            credentials_json = profile.get_profile_var(["google", "credentials_json"])
+        else:
             self.skipTest("Please set " + google_env_var)
+        if(not os.path.isfile(os.path.expanduser(credentials_json))):
+            self.skiptest("Credentials file {} does not exist".format(credentials_json))
 
         try:
             self.passive_stt_engine = testutils.get_plugin_instance(
@@ -41,4 +49,3 @@ class TestGoogleSTTPlugin(unittest.TestCase):
         with open(self.time_clip, mode="rb") as f:
             transcription = self.active_stt_engine.transcribe(f)
         self.assertIn("TIME", transcription)
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I noticed that the test requires the environment variable to
exist in order to not be skipped, but then in the main google.py
module, you are getting the location of the file from profile.py.

I think this modification will favor the environment variable over
the profile.py setting (if both are set, the environment variable
wins) in both the google.py and tests/test_googlesttplugin.py.

I haven't had a chance to thoroughly test this yet, but I did
run unittest discovery against it with a valid authorization file
in profile.yml and that worked.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#166 Google stt plugin is broken](https://github.com/NaomiProject/Naomi/issues/166)
